### PR TITLE
Bugfixes addressing installation on Mac/Linux.

### DIFF
--- a/install/mac_linux/epictope_install.sh
+++ b/install/mac_linux/epictope_install.sh
@@ -31,14 +31,19 @@ else
 
     # Create a new conda environment for epictope
     conda create -n epictope
-    conda activate epictope
-    conda install -c bioconda blast muscle
-    conda install -c salilab dssp
-    conda install -c anaconda "openssl>=3.0.9"
-    conda install -c conda-forge r-base r-stringi r-openssl r-remotes "python>=3.11.4"
+    conda install -n epictope -c bioconda blast muscle
+    conda install -n epictope -c salilab dssp
+    conda install -n epictope -c anaconda "openssl>=3.0.9"
+    conda install -n epictope -c conda-forge r-base r-stringi r-openssl r-remotes "python>=3.11.4"
+    conda install -n epictope libboost=1.73.0 # for compatibility for dssp 3
     
-    # Install R packages
+    # Install R packages in the epictope environment
+    (
+    source $(conda info --base)/etc/profile.d/conda.sh
+    conda activate epictope
     R -e "remotes::install_github('FriedbergLab/EpicTope')"
+    conda deactivate
+    )
     # Install epitope_tag scripts
     curl -O "https://raw.githubusercontent.com/FriedbergLab/Epictope/main/scripts/single_score.R" 
     curl -O "https://raw.githubusercontent.com/FriedbergLab/Epictope/main/scripts/plot_scores.R" 

--- a/install/mac_linux/epictope_install.sh
+++ b/install/mac_linux/epictope_install.sh
@@ -34,8 +34,8 @@ else
     conda activate epictope
     conda install -c bioconda blast muscle
     conda install -c salilab dssp
-    conda install -c anaconda openssl>=3.0.9
-    conda install -c conda-forge r-base r-stringi r-openssl r-remotes python>=3.11.4
+    conda install -c anaconda "openssl>=3.0.9"
+    conda install -c conda-forge r-base r-stringi r-openssl r-remotes "python>=3.11.4"
     
     # Install R packages
     R -e "remotes::install_github('FriedbergLab/EpicTope')"

--- a/install/mac_linux/epictope_install.sh
+++ b/install/mac_linux/epictope_install.sh
@@ -40,10 +40,10 @@ else
     # Install R packages
     R -e "remotes::install_github('FriedbergLab/EpicTope')"
     # Install epitope_tag scripts
-    curl -O "https://raw.githubusercontent.com/henrichung/epitope_tag/main/scripts/single_score.R" 
-    curl -O "https://raw.githubusercontent.com/henrichung/epitope_tag/main/scripts/plot_scores.R" 
-    curl -O "https://raw.githubusercontent.com/henrichung/epitope_tag/main/scripts/install.R"
-    curl -O "https://raw.githubusercontent.com/henrichung/epitope_tag/main/scripts/config_defaults.R" 
+    curl -O "https://raw.githubusercontent.com/FriedbergLab/Epictope/main/scripts/single_score.R" 
+    curl -O "https://raw.githubusercontent.com/FriedbergLab/Epictope/main/scripts/plot_scores.R" 
+    curl -O "https://raw.githubusercontent.com/FriedbergLab/Epictope/main/scripts/install.R"
+    curl -O "https://raw.githubusercontent.com/FriedbergLab/Epictope/main/scripts/config_defaults.R" 
 fi
 
 


### PR DESCRIPTION
Introduction:
=============

Dear Parnal and FriedbergLab, thanks so much for this very useful `Epictope` software! In the Mullins Lab, we've been testing the program for our purposes and have run into a couple of issues with installing and running the software. This pull request contains some suggested fixes, addressing principally the `Epictope` installation on Mac and Linux.

Installation of Epictope on Mac and Linux:
==========================================

1. The `curl` URLs for the `R` scripts in install/mac_linux/epictope_install.sh appear to be out-of-date. I have updated these in commit f2002ff8a2e709bb7c23cd523401e49367cc57a2.

2. In install/mac_linux/epictope_install.sh, in our shell the `conda` expressions `openssl>=3.0.9` and `python>=3.11.4` cause the installer to hang and drop files called =3.0.9 and =3.11.4 into the working directory. I think what is happening is that the shell is interpreting the `>` character as a redirect operateor, causing the `conda` prompts to be redirected to a file and therefore causing the installer to hang indefinitely waiting for user input. To fix this problem, I quoted these two expressions in commit 558a3de9a8a7fd8cc4f91ac4e4c4ac8b6084d3d9.

3. The use of `conda activate` in shell scripts can sometimes be problematic (see https://github.com/conda/conda/issues/7980 for details), as used in install/mac_linux/epictope_install.sh. Interestingly, this worked fine on a Linux system, but we had problems installing on a Mac, with `conda` complaining about `run conda init before conda activate`. I think what is happening here is that the `conda` commands, while present in the main shell, are not necessarily available in the subshell created by `bash -i epictope_install.sh`. To fix this problem, I used the `-n` flag with `conda` to explicitly install packages into the `epictope` environment, without requiring `conda activate`. To install the `R` package for `Epictope`, I created a subshell with the `conda` commands available, used `conda activate epictope`, and then installed the `R` packages. These changes are in commit 420504b8289cb387a348ebc041da9d74a6d89f6f.

4. The latest version of `dssp` available on Anaconda is actually an older version (version 3, latest version on GitHub at https://github.com/PDB-REDO/dssp is > 4), and it appears to depend on an older version of `libboost`, version 1.73.0. I added a `conda install` command to add this package to the `epictope` environment in commit 420504b8289cb387a348ebc041da9d74a6d89f6f.