### PR TITLE
Fixes for DSSP version 4 Compatibility

### DIFF
--- a/R/check_config.R
+++ b/R/check_config.R
@@ -41,7 +41,8 @@ check_config <- function() {
       "C" = 1,
       "T" = 0.5,
       "B" = 0.5,
-      "S" = 0.5)
+      "S" = 0.5,
+      "P" = 0)
     assign("ss_key", ss_key, envir = .GlobalEnv)
 
     # reference values for maximum solvent accessibility of amino acids.

--- a/R/dssp_command.R
+++ b/R/dssp_command.R
@@ -20,7 +20,7 @@ dssp_command <- function(pdb_file) {
   output_file <- gsub("\\.pdb.gz|\\.pdb", ".dssp", pdb_file)
 
   # Run the DSSP command with mkdssp, return error message if an error occurs.
-  system(command = paste0("mkdssp -i ", pdb_file, " -o ", output_file), intern = TRUE)
+  system(command = paste0("mkdssp ", pdb_file, " ", output_file), intern = TRUE)
 
   # Return the name of the output file.
   return(output_file)

--- a/R/ss_convert.R
+++ b/R/ss_convert.R
@@ -15,7 +15,7 @@
 
 ss_convert <- function(.x) {
   # Check if .x is a recognized Secondary Structure Symbol
-  if (!grepl("[GHIECTBS]", .x)) {
+  if (!grepl("[GHIECTBSP]", .x)) {
     # If not, print an error message and return NULL
     message("Character is not a recognized Secondary Structure Symbol.")
     return(NULL)

--- a/install/mac_linux/epictope_install.sh
+++ b/install/mac_linux/epictope_install.sh
@@ -31,14 +31,19 @@ else
 
     # Create a new conda environment for epictope
     conda create -n epictope
-    conda activate epictope
-    conda install -c bioconda blast muscle
-    conda install -c salilab dssp
-    conda install -c anaconda "openssl>=3.0.9"
-    conda install -c conda-forge r-base r-stringi r-openssl r-remotes "python>=3.11.4"
+    conda install -n epictope -c bioconda blast muscle
+    conda install -n epictope -c salilab dssp
+    conda install -n epictope -c anaconda "openssl>=3.0.9"
+    conda install -n epictope -c conda-forge r-base r-stringi r-openssl r-remotes "python>=3.11.4"
+    conda install -n epictope libboost=1.73.0 # for compatibility for dssp 3
     
-    # Install R packages
+    # Install R packages in the epictope environment
+    (
+    source $(conda info --base)/etc/profile.d/conda.sh
+    conda activate epictope
     R -e "remotes::install_github('FriedbergLab/EpicTope')"
+    conda deactivate
+    )
     # Install epitope_tag scripts
     curl -O "https://raw.githubusercontent.com/FriedbergLab/Epictope/main/scripts/single_score.R" 
     curl -O "https://raw.githubusercontent.com/FriedbergLab/Epictope/main/scripts/plot_scores.R" 

--- a/install/mac_linux/epictope_install.sh
+++ b/install/mac_linux/epictope_install.sh
@@ -34,8 +34,8 @@ else
     conda activate epictope
     conda install -c bioconda blast muscle
     conda install -c salilab dssp
-    conda install -c anaconda openssl>=3.0.9
-    conda install -c conda-forge r-base r-stringi r-openssl r-remotes python>=3.11.4
+    conda install -c anaconda "openssl>=3.0.9"
+    conda install -c conda-forge r-base r-stringi r-openssl r-remotes "python>=3.11.4"
     
     # Install R packages
     R -e "remotes::install_github('FriedbergLab/EpicTope')"

--- a/install/mac_linux/epictope_install.sh
+++ b/install/mac_linux/epictope_install.sh
@@ -31,10 +31,10 @@ else
 
     # Create a new conda environment for epictope
     conda create -n epictope
-    conda install -n epictope -c bioconda --override-channels blast muscle
-    conda install -n epictope -c salilab --override-channels dssp
-    conda install -n epictope -c anaconda --override-channels "openssl>=3.0.9"
-    conda install -n epictope -c conda-forge --override-channels r-base r-stringi r-openssl r-remotes "python>=3.11.4"
+    conda install -n epictope -c bioconda blast muscle
+    conda install -n epictope -c salilab dssp
+    conda install -n epictope -c anaconda "openssl>=3.0.9"
+    conda install -n epictope -c conda-forge r-base r-stringi r-openssl r-remotes "python>=3.11.4"
     conda install -n epictope libboost=1.73.0 # for compatibility for dssp 3
     
     # Install R packages in the epictope environment

--- a/install/mac_linux/epictope_install.sh
+++ b/install/mac_linux/epictope_install.sh
@@ -40,10 +40,10 @@ else
     # Install R packages
     R -e "remotes::install_github('FriedbergLab/EpicTope')"
     # Install epitope_tag scripts
-    curl -O "https://raw.githubusercontent.com/henrichung/epitope_tag/main/scripts/single_score.R" 
-    curl -O "https://raw.githubusercontent.com/henrichung/epitope_tag/main/scripts/plot_scores.R" 
-    curl -O "https://raw.githubusercontent.com/henrichung/epitope_tag/main/scripts/install.R"
-    curl -O "https://raw.githubusercontent.com/henrichung/epitope_tag/main/scripts/config_defaults.R" 
+    curl -O "https://raw.githubusercontent.com/FriedbergLab/Epictope/main/scripts/single_score.R" 
+    curl -O "https://raw.githubusercontent.com/FriedbergLab/Epictope/main/scripts/plot_scores.R" 
+    curl -O "https://raw.githubusercontent.com/FriedbergLab/Epictope/main/scripts/install.R"
+    curl -O "https://raw.githubusercontent.com/FriedbergLab/Epictope/main/scripts/config_defaults.R" 
 fi
 
 

--- a/install/mac_linux/epictope_install.sh
+++ b/install/mac_linux/epictope_install.sh
@@ -31,10 +31,10 @@ else
 
     # Create a new conda environment for epictope
     conda create -n epictope
-    conda install -n epictope -c bioconda blast muscle
-    conda install -n epictope -c salilab dssp
-    conda install -n epictope -c anaconda "openssl>=3.0.9"
-    conda install -n epictope -c conda-forge r-base r-stringi r-openssl r-remotes "python>=3.11.4"
+    conda install -n epictope -c bioconda --override-channels blast muscle
+    conda install -n epictope -c salilab --override-channels dssp
+    conda install -n epictope -c anaconda --override-channels "openssl>=3.0.9"
+    conda install -n epictope -c conda-forge --override-channels r-base r-stringi r-openssl r-remotes "python>=3.11.4"
     conda install -n epictope libboost=1.73.0 # for compatibility for dssp 3
     
     # Install R packages in the epictope environment

--- a/scripts/config_defaults.R
+++ b/scripts/config_defaults.R
@@ -25,7 +25,8 @@ ss_key <- list(
     "C" = 1,
     "T" = 0.5,
     "B" = 0.5,
-    "S" = 0.5)
+    "S" = 0.5,
+    "P" = 0)
 assign("ss_key", ss_key, envir = .GlobalEnv)
 
 # reference values for maximum solvent accessibility of amino acids.


### PR DESCRIPTION
Introduction:
=========

The changes suggested in this branch fix compatibility of `Epictope` with `dssp` version 4, without breaking compatibility with `dssp` version 3 or version 2.

The current version of `dssp` on the salilab `conda` channel is version 3, which is older than the current version of `dssp` (https://github.com/PDB-REDO/dssp). In `dssp` version 4, a number of changes were introduced which break compatibility with `Epictope`: namely (1) the use of the `-i` and `-o` flags for the input and output files of `mkdssp` is no longer allowed, and (2) version 4 also incorporates a new secondary structure code, "P = κ-helix (poly-proline II helix)" (see https://pdb-redo.eu/dssp/about for details).

Users may need to install a newer version of `dssp` to utilize its newer features such as full mmCIF support. Furthermore, `dssp` version 3 is not available for ARM64 Macs on `conda`. Version 4 can be built from source on ARM64 Macs and is also available on conda (for example, from the sbl channel). I propose also updating the installer script to use updated `dssp` version (for example `conda install -c sbl dssp`). However, I have not incorporated this suggested change into this branch.

Thanks again for developing the `Epictope` software!

Updated Compatibility with DSSP version 4:
=============================

All changes are incorporated into commit e99bca41e961d18f381f49294e21764705d12d98.

1. `mkdssp` 4 does not allow the use of `-i` and `-o` flags, requiring the input and output files to be supplied as positional arguments, e.g. `mkdssp in out` rather than `mkdssp -i in -o out`. On the other hand, `mkdssp` 2 and 3 both allow the use of the positional arguments (the documentation suggests `-i` and `-o` but testing indicates that it is not required). I dropped the use of `-i` and `-o` in Epictope/R/dssp_command.R, which makes `Epictope` compatible with `mkdssp` 4 while preserving backwards compatibility with versions 2 and 3.

2. `mkdssp` 4 outputs a new secondary structure, called P, which is not currently allowed in `Epictope`. I updated `ss_key` to include `P=0` and also added it as an allowed value to R/ss_convert.R.