### PR TITLE
Custom Structures in mmCIF Format for Epictope

### DIFF
--- a/R/dssp_command.R
+++ b/R/dssp_command.R
@@ -17,7 +17,7 @@ dssp_command <- function(pdb_file) {
   stopifnot(is.character(pdb_file))
 
   # Define output filename by replacing the extension with ".dssp"
-  output_file <- gsub("\\.pdb.gz|\\.pdb", ".dssp", pdb_file)
+  output_file <- gsub("\\.cif.gz|\\.cif", ".dssp", pdb_file)
 
   # Run the DSSP command with mkdssp, return error message if an error occurs.
   system(command = paste0("mkdssp ", pdb_file, " ", output_file), intern = TRUE)

--- a/R/fetch_alphafold.R
+++ b/R/fetch_alphafold.R
@@ -22,7 +22,7 @@ fetch_alphafold <- function(protein_id) {
   base_url <- "https://alphafold.ebi.ac.uk/files/"
 
   # Set the version suffix
-  version_suffix <- "-F1-model_v6.pdb"
+  version_suffix <- "-F1-model_v6.cif"
 
   # Define output filename
   filename <- paste0("AF-", protein_id, version_suffix)

--- a/R/parse_dssp.R
+++ b/R/parse_dssp.R
@@ -33,9 +33,9 @@ parse_dssp <- function(file, keepfiles = TRUE) {
       l <- strsplit(line, split = "")[[1]]
       l <- paste(l, collapse = "")
       if ("have bz2" %in% l) {
-          if(.Platform$OS.type == "unix") {first_valid_line <- 29} else {first_valid_line <- 28}
+          if(.Platform$OS.type == "unix") {first_valid_line <- 29} else {first_valid_line <- 29}
       } else {
-          if(.Platform$OS.type == "unix") {first_valid_line <- 28} else {first_valid_line <- 27}
+          if(.Platform$OS.type == "unix") {first_valid_line <- 28} else {first_valid_line <- 28}
       }
     }
 

--- a/R/ss_convert.R
+++ b/R/ss_convert.R
@@ -18,7 +18,7 @@ ss_convert <- function(.x) {
   if (!grepl("[GHIECTBSP]", .x)) {
     # If not, print an error message and return NULL
     message("Character is not a recognized Secondary Structure Symbol.")
-    return(NULL)
+    return(NA)
   } else {
     # Return the numeric value corresponding to the Secondary Structure Symbol as defined in the SS_key
     return(ss_key[.x])

--- a/README.md
+++ b/README.md
@@ -117,6 +117,15 @@ Rscript install.R
 Rscript single_score.R Q9W7E7
 ```
 
+### Example 1C: Generating EpicTope predictions for custom AlphaFold structures
+
+Some UniProt entries do not have a corresponding AlphaFold prediction yet. To use a custom structure, first identify the Uniprot ID as described in example 1A, and select the "Sequence" tab (for example: [Q9W7E7](https://www.uniprot.org/uniprotkb/Q9W7E7/entry#sequences)). Submit the exact sequence to [AlphaFold](https://alphafoldserver.com/). Download the results, and copy one of the .cif files to the `data/models` directory of `epictope`. Finally, supply the path to the custom structure as a command-line input to `epictope`:
+```bash
+conda activate epictope
+Rscript install.R
+Rscript single_score.R Q9W7E7 data/models/custom_model_of_Q9W7E7.cif
+```
+
 ### Example 2: Viewing your results.
 
 The EpicTope workflow generates a "\<UniprotID\>_score.csv" file (ex: Q9W7E7_score.csv), containing the individual feature scores for each position, the minimum score across features for each position, and a weighted sum score of all features. These values can be plotted in the data visualization tool of choice.

--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ conda activate epictope
 Rscript install.R
 Rscript single_score.R Q9W7E7 data/models/custom_model_of_Q9W7E7.cif
 ```
+Sometimes, the user-supplied structure file may contain only one portion of the complete protein, for example, when the AlphaFold Server limits the user-supplied sequence. In this case, the first residue of the custom structure can be supplied as an addition argument (the N-terminal residue of the protein is residue 1). For example, if the custom structure starts at residue 57 of the protein:
+```
+Rscript single_score.R Q9W7E7 data/models/custom_model_of_Q9W7E7.cif 57
+```
 
 ### Example 2: Viewing your results.
 

--- a/install/mac_linux/epictope_install.sh
+++ b/install/mac_linux/epictope_install.sh
@@ -7,8 +7,20 @@ if ! command -v conda &> /dev/null; then
     # Determine the OS and set the appropriate miniconda installer URL
     case "$(uname -s)" in
         Darwin)
-            installer_url="https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
-            installer_name="Miniconda3-latest-MacOSX-x86_64.sh"
+            case "$(uname -m)" in
+                x86-64)
+                    installer_url="https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
+                    installer_name="Miniconda3-latest-MacOSX-x86_64.sh"
+                    ;;
+                arm64)
+                    installer_url="https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh"
+                    installer_name="Miniconda3-latest-MacOSX-arm64.sh"
+                    ;;
+                *)
+                    echo "Unsupported operating system."
+                    exit 1
+                    ;;
+            esac
             ;;
         Linux)
             installer_url="https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh"
@@ -31,11 +43,9 @@ else
 
     # Create a new conda environment for epictope
     conda create -n epictope
+    conda install -n epictope -c conda-forge dssp
     conda install -n epictope -c bioconda blast muscle
-    conda install -n epictope -c salilab dssp
-    conda install -n epictope -c anaconda "openssl>=3.0.9"
     conda install -n epictope -c conda-forge r-base r-stringi r-openssl r-remotes r-curl r-rvest r-httr "r-r.utils" r-biocmanager "python>=3.11.4"
-    conda install -n epictope libboost=1.73.0 # for compatibility for dssp 3
     
     # Install R packages in the epictope environment
     (

--- a/install/mac_linux/epictope_install.sh
+++ b/install/mac_linux/epictope_install.sh
@@ -34,13 +34,14 @@ else
     conda install -n epictope -c bioconda blast muscle
     conda install -n epictope -c salilab dssp
     conda install -n epictope -c anaconda "openssl>=3.0.9"
-    conda install -n epictope -c conda-forge r-base r-stringi r-openssl r-remotes "python>=3.11.4"
+    conda install -n epictope -c conda-forge r-base r-stringi r-openssl r-remotes r-curl r-rvest r-httr "r-r.utils" r-biocmanager "python>=3.11.4"
     conda install -n epictope libboost=1.73.0 # for compatibility for dssp 3
     
     # Install R packages in the epictope environment
     (
     source $(conda info --base)/etc/profile.d/conda.sh
     conda activate epictope
+    R -e "BiocManager::install('Biostrings')"
     R -e "remotes::install_github('FriedbergLab/EpicTope')"
     conda deactivate
     )

--- a/install/windows/epictope_install.bat
+++ b/install/windows/epictope_install.bat
@@ -13,19 +13,24 @@ if %errorlevel% neq 0 (
     call conda create --name epictope --yes
 )
 :: activate the 'Epictope' environment and install dependencies
+call conda install -n epictope -c conda-forge dssp --yes
+call conda install -n epictope -c conda-forge r-base r-stringi r-openssl r-remotes r-curl r-rvest r-httr "r-r.utils" r-biocmanager --yes
 call conda activate epictope
-call conda install -c speleo3 dssp --yes
-call conda install -c conda-forge r-base r-stringi r-openssl r-remotes --yes
+call conda env config vars set -n epictope LIBCIFPP_DATA_DIR="%CONDA_PREFIX%\share\libcifpp"
+powershell -Command "(New-Object Net.WebClient).DownloadFile('https://files.wwpdb.org/pub/pdb/data/monomers/components.cif', '%CONDA_PREFIX%\share\libcifpp\components.cif')"
+call conda deactivate
 :: report success
 echo Epictope environment installation complete.
 
 :: Installing Bioconductor dependencies inside conda env
+call conda activate epictope
 echo Installing Bioconductor dependencies inside conda environment...
 call R -e "rlib <- file.path(Sys.getenv('CONDA_PREFIX'),'Lib','R','library'); if(!dir.exists(rlib)) dir.create(rlib, recursive=TRUE); .libPaths(rlib); if(!requireNamespace('BiocManager', quietly=TRUE)) install.packages('BiocManager', repos='https://cloud.r-project.org'); BiocManager::install(c('S4Vectors','IRanges','XVector','Biostrings','GenomeInfoDb'), ask=FALSE)"
 
 :: BLAST INSTALLATION
 :: Check if the file exists
-if exist ncbi-blast-2.7.1+-win64.exe (
+where /q blastn
+if ERRORLEVEL 0 (
     echo Blast executable found. Skipping installation.
 ) else (
     :: Download the blast installer
@@ -48,7 +53,7 @@ if exist muscle.exe (
 ) else (
     :: Download the MUSCLE installer
     echo Downloading MUSCLE...
-    powershell -Command "(New-Object Net.WebClient).DownloadFile('https://github.com/rcedgar/muscle/releases/download/5.1.0/muscle5.1.win64.exe', '%cd%\muscle5.1.win64.exe')"
+    powershell -Command "(New-Object Net.WebClient).DownloadFile('https://github.com/rcedgar/muscle/releases/download/v5.1/muscle5.1.win64.exe', '%cd%\muscle5.1.win64.exe')"
     echo Renaming MUSCLE executable...
     move muscle5.1.win64.exe muscle.exe
     :: report success

--- a/scripts/single_score.R
+++ b/scripts/single_score.R
@@ -10,17 +10,30 @@ rm(list = ls())
 setup_files()
 check_config()
 args <- commandArgs(trailingOnly = TRUE); query <- args[1]
+if (length(args) == 2) {
+    message("Using user-supplied structure file.")
+    if (!file.exists(args[2])) {
+        stop("User-supplied structure file does not exist: ", args[2])
+    }
+    alphafold_file_custom <- args[2]
+} else {
+    alphafold_file_custom <- NULL
+}
 # download uniprot information 
 uniprot_fields <- c("accession", "id", "gene_names", "xref_alphafolddb", "sequence", "organism_name", "organism_id")
 uniprot_data <- query_uniProt(query = query, fields = uniprot_fields)
 
 ####
 # download associated alphafold2 pdb
-if(is.na(uniprot_data$AlphaFoldDB)){
-  message("WARNING. NO CROSSREFERENCE ALPHAFOLD ENTRY FOUND; ATTEMPTING DIRECT LOOKUP. RESULTS MAY BE LOW CONFIDENCE.")
-  uniprot_data$AlphaFoldDB <- query}
-alphafold_file <- fetch_alphafold(gsub(";", "", uniprot_data$AlphaFoldDB))
-if(is.na(alphafold_file)){stop("No alphafold file found for ", query)}
+if (is.null(alphafold_file_custom)) {
+    if(is.na(uniprot_data$AlphaFoldDB)){
+      message("WARNING. NO CROSSREFERENCE ALPHAFOLD ENTRY FOUND; ATTEMPTING DIRECT LOOKUP. RESULTS MAY BE LOW CONFIDENCE.")
+      uniprot_data$AlphaFoldDB <- query}
+    alphafold_file <- fetch_alphafold(gsub(";", "", uniprot_data$AlphaFoldDB))
+    if(is.na(alphafold_file)){stop("No alphafold file found for ", query)}
+} else {
+    alphafold_file <- alphafold_file_custom
+}
 # calculate dssp on alphafold pdb file
 dssp_res <- dssp_command(alphafold_file)
 # parse and read in dssp

--- a/scripts/single_score.R
+++ b/scripts/single_score.R
@@ -10,7 +10,7 @@ rm(list = ls())
 setup_files()
 check_config()
 args <- commandArgs(trailingOnly = TRUE); query <- args[1]
-if (length(args) == 2) {
+if (length(args) >= 2) {
     message("Using user-supplied structure file.")
     if (!file.exists(args[2])) {
         stop("User-supplied structure file does not exist: ", args[2])
@@ -38,6 +38,13 @@ if (is.null(alphafold_file_custom)) {
 dssp_res <- dssp_command(alphafold_file)
 # parse and read in dssp
 dssp_df <- parse_dssp(dssp_res)
+if (!is.null(alphafold_file_custom) & length(args) == 2) {
+    message("No starting residue index provided for user-supplied structure file. Assuming user-supplied structure file starts with residue 1.")
+} else if (!is.null(alphafold_file_custom) & length(args) == 3) {
+    message("User-supplied structure file starts with residue index ", args[3], ".")
+    dssp_df$resnum <- dssp_df$resnum + as.numeric(args[3]) - 1
+    dssp_df$position <- as.character(as.numeric(dssp_df$position) + as.numeric(args[3]) - 1)
+}
 
 # retrieve iupred/anchor2 disordered binding regions
 iupred_df <- iupredAnchor(query)


### PR DESCRIPTION
`Epictope` continues to be of great use to our lab: thanks for the great software! This pull request addresses a few issues that we have identifed when using `Epictope`. Most importantly, it provides an option to supply a user-specified .cif file to `Epictope`, enabling users to use `Epictope` on custom AlphaFold simulations.

# Fixing installation issues on Linux:
`Epictope` does not install successfully on some versions of Linux. It appears that some of the required `R` packages are not compiled correctly by the C compiler that comes with `conda`. To avoid this issue, I suggest installing pre-compiled versions of these troublesome `R` packages with `conda` instead of compiling them in `R` within the `conda` environment. These changes are included in commit 8bd7b64e884912599b768653dc1cb0c4bc9ec8e3.

# Full upgrade to `dssp` version 4 with mmCIF support:
The latest version of `Epictope` supports PDB files but not mmCIF, which is now the recommended file format used by the Protein Data Bank (https://doi.org/10.1007/s10822-014-9770-y). Complicating matters, new AlphaFold simulations are provided in .cif format only, precluding users from supplying these files to `Epictope` unless they first convert them to .pdb format. Finally, `dssp` versions 2 and 3, which support the legacy PDB format, are not currently available for newer Apple computers using the ARM64 architecture (Apple silicon) with `conda`, making `Epictope` incompatible with many newer Macs. Commit 396477d95caf8147dfacdd5364beb970e97a4cf2 addresses these shortcomings by updating the Mac/Linux installer to use `dssp` version 4 and updating `Epictope` to retrieve .cif files from AlphaFold and accept .cif files as input. Commit 2cb6206061a49ba04643055b1d645fe6d2ff9809 similarly updates the Windows installer. Consequently, `Epictope` now supports ARM64-based Macs and the newer .cif file format.

# Option to supply a user-defined .cif file:
`Epictope` works very nicely for proteins listed in Uniprot that already have structures predicted by AlphaFold. However, not every Uniprot protein has an associated AlphaFold structure. We are using `Epictope` in our lab to tag some of these proteins that do not yet have an AlphaFold structure. Commit 31be6d5bf86d6db7bb5c361bd269b44817d9727a enables `Epictope` to accept a user-specified .cif file as a command-line argument, if desired, along with the corresponding Uniprot ID. Users can submit their sequences to AlphaFold, download a .cif output, and submit it to `Epictope.` An example is provided in the updated README in commit 5a3669613e990a2a715d6109836f7b0faaa68b76.